### PR TITLE
Add #to_h method for conversion to hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.1.2] - 2017-11-03
+
+Added #to_h to allow conversion of objects to hashes, allowing for easier 
+testing via hash comparison.
+
 ## [0.1.1] - 2017-03-20
 
 Added support for handling JSON keys that start with integers. Previously this was attempting to use an invalid instance variable ("@1234"). New behavior prepends instance variables and method access calls with an underscore: `obj._1234` or `obj.instance_variable_get("_@1234")`.

--- a/lib/arendelle.rb
+++ b/lib/arendelle.rb
@@ -1,5 +1,5 @@
 class Arendelle
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 
   def initialize(**opts)
     opts.each { |k, v| self[k] = v }
@@ -19,6 +19,15 @@ class Arendelle
       define_singleton_method(key) do
         instance_variable_get(ivar)
       end
+    end
+  end
+
+  def to_h
+    instance_variables.each_with_object({}) do |ivar, hash|
+      key = ivar.to_s[2..-1]
+      value = send(key)
+      new_value = value.is_a?(Arendelle) ? value.to_h : value
+      hash[key.to_sym] = new_value
     end
   end
 end

--- a/spec/arendelle_spec.rb
+++ b/spec/arendelle_spec.rb
@@ -38,4 +38,30 @@ RSpec.describe Arendelle do
       end
     end
   end
+
+  describe "#to_h" do
+    it "should convert itself to a hash-like structure" do
+      obj = Arendelle.new(name: "First Name", other: "Sure")
+      data = { name: "First Name", other: "Sure" }
+      expect(obj.to_h).to eq data
+    end
+
+    it "should convert nested Arendelle instances" do
+      obj = Arendelle.new(
+        name: "First Name",
+        other: Arendelle.new(
+          nested: Arendelle.new(double_nested: "Double Nested")
+        )
+      )
+      data = {
+        name: "First Name",
+        other: {
+          nested: {
+            double_nested: "Double Nested"
+          }
+        }
+      }
+      expect(obj.to_h).to eq data
+    end
+  end
 end


### PR DESCRIPTION
Adds #to_h method to allow easier testing against
Arendelle objects in RSpec via existing hash
comparisons.